### PR TITLE
Expand HTTPMethod to include PATCH, HEAD, OPTIONS, CONNECT and TRACE.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "Mu",
-    platforms: [.iOS(.v15),.macOS(.v12),.watchOS(.v8)],
+    platforms: [.iOS(.v15),.macOS(.v12),.watchOS(.v8), .tvOS(.v15)],
     products: [
         .library(
             name: "Mu",

--- a/Sources/Mu/HTTPMethod.swift
+++ b/Sources/Mu/HTTPMethod.swift
@@ -21,17 +21,27 @@
 
 
 public enum HTTPMethod: CustomStringConvertible {
+    case get
+    case head
     case post
     case put
-    case get
     case delete
+    case patch
+    case connect
+    case options
+    case trace
     
     public var description: String {
         switch self {
-        case .delete: return "DELETE"
-        case .put: return "PUT"
         case .get: return "GET"
+        case .head: return "HEAD"
         case .post: return "POST"
+        case .put: return "PUT"
+        case .delete: return "DELETE"
+        case .patch: return "PATCH"
+        case .connect: return "CONNECT"
+        case .options: return "OPTIONS"
+        case .trace: return "TRACE"
         }
     }
 }

--- a/Tests/MuTests/HTTPMethodTests.swift
+++ b/Tests/MuTests/HTTPMethodTests.swift
@@ -23,19 +23,39 @@ import XCTest
 @testable import Mu
 
 final class HTTPMethodTests: XCTestCase {
-    func testHTTPMethodGetDescription() {
+    func testHTTPMethodGETDescription() {
         XCTAssertEqual(HTTPMethod.get.description, "GET")
     }
     
-    func testHTTPMethodPostDescription() {
+    func testHTTPMethodHEADDescription() {
+        XCTAssertEqual(HTTPMethod.head.description, "HEAD")
+    }
+    
+    func testHTTPMethodPOSTDescription() {
         XCTAssertEqual(HTTPMethod.post.description, "POST")
     }
     
-    func testHTTPMethodDeleteDescription() {
+    func testHTTPMethodPUTDescription() {
+        XCTAssertEqual(HTTPMethod.put.description, "PUT")
+    }
+    
+    func testHTTPMethodDELETEDescription() {
         XCTAssertEqual(HTTPMethod.delete.description, "DELETE")
     }
     
-    func testHTTPMethodPutDescription() {
-        XCTAssertEqual(HTTPMethod.put.description, "PUT")
+    func testHTTPMethodPATCHDescription() {
+        XCTAssertEqual(HTTPMethod.patch.description, "PATCH")
+    }
+    
+    func testHTTPMethodCONNECTDescription() {
+        XCTAssertEqual(HTTPMethod.connect.description, "CONNECT")
+    }
+    
+    func testHTTPMethodOPTIONSDescription() {
+        XCTAssertEqual(HTTPMethod.options.description, "OPTIONS")
+    }
+    
+    func testHTTPMethodTRACEDescription() {
+        XCTAssertEqual(HTTPMethod.trace.description, "TRACE")
     }
 }


### PR DESCRIPTION
## Summary
Expand HTTPMethod to include PATCH, HEAD, OPTIONS, CONNECT and TRACE.

As well as enable tvOS as a platform.